### PR TITLE
Implement theme and shortcut customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Verbalize is an advanced Markdown editor with grammatical and stylistic analysis
 - **Minimalist Interface**: A clean, writing-focused design with a responsive layout adaptable to different screen sizes.
 - **Desktop Application**: Available as a cross-platform desktop app using Electron.
 - **More Readability Metrics**: Extra formulas and progress bars to visualize Flesch scores.
+- **Theme Selection and Shortcuts**: Choose between light and dark modes and use handy keyboard shortcuts.
 
 ## Screenshots
 
@@ -208,6 +209,7 @@ O editor Verbalize analisa seu texto em busca de:
 - **Highlight.js**: Realce de sintaxe para blocos de código na pré-visualização.
 - **Bootstrap popovers**: Exibição de mensagens de aviso ao interagir com trechos destacados.
 - **DOMPurify**: Sanitização do conteúdo para evitar execução de código malicioso.
+- **Escolha de tema e atalhos**: Selecione entre os modos claro e escuro e utilize atalhos de teclado.
 
 ## Tecnologias Utilizadas
 

--- a/index.html
+++ b/index.html
@@ -57,6 +57,10 @@
             <option value="en">English</option>
             <option value="es">Español</option>
         </select>
+        <select id="theme-selector" class="form-select form-select-sm" style="width:auto; display:inline-block; margin-left:8px;">
+            <option value="light">Claro</option>
+            <option value="dark">Escuro</option>
+        </select>
     </div>
     <div id="sugestao-texto-ia" class="mt-2"></div>
 </div>
@@ -70,6 +74,7 @@
 <script src="libs/ace.js"></script>
 <script src="libs/mode-markdown.js"></script>
 <script src="libs/theme-chrome.js"></script>
+<script src="libs/theme-custom_dark.js"></script>
 <!-- Markdown-it -->
 <script src="libs/markdown-it.min.js"></script>
 <!-- Plugin Footnote do Markdown-it -->

--- a/libs/theme-custom_dark.js
+++ b/libs/theme-custom_dark.js
@@ -1,0 +1,42 @@
+define("ace/theme/custom_dark",["require","exports","module","ace/lib/dom"],function(require, exports, module){
+    exports.isDark = true;
+    exports.cssClass = "ace-custom-dark";
+    exports.cssText = ".ace-custom-dark .ace_gutter {\n" +
+        "background: #2b2b2b;\n" +
+        "color: #8f908a;\n" +
+    "}\n" +
+    ".ace-custom-dark {\n" +
+        "background-color: #1e1e1e;\n" +
+        "color: #f8f8f2;\n" +
+    "}\n" +
+    ".ace-custom-dark .ace_cursor {\n" +
+        "color: #f8f8f0;\n" +
+    "}\n" +
+    ".ace-custom-dark .ace_marker-layer .ace_selection {\n" +
+        "background: #3e4451;\n" +
+    "}\n" +
+    ".ace-custom-dark.ace_multiselect .ace_selection.ace_start {\n" +
+        "box-shadow: 0 0 3px 0px #1e1e1e;\n" +
+    "}\n" +
+    ".ace-custom-dark .ace_marker-layer .ace_step {\n" +
+        "background: rgb(102, 82, 0);\n" +
+    "}\n" +
+    ".ace-custom-dark .ace_marker-layer .ace_bracket {\n" +
+        "margin: -1px 0 0 -1px;\n" +
+        "border: 1px solid #3e4451;\n" +
+    "}\n" +
+    ".ace-custom-dark .ace_marker-layer .ace_active-line {\n" +
+        "background: #383c4a;\n" +
+    "}\n" +
+    ".ace-custom-dark .ace_gutter-active-line {\n" +
+        "background-color: #383c4a;\n" +
+    "}\n" +
+    ".ace-custom-dark .ace_marker-layer .ace_selected-word {\n" +
+        "border: 1px solid #3e4451;\n" +
+    "}\n" +
+    ".ace-custom-dark .ace_invisible {\n" +
+        "color: #52524d;\n" +
+    "}";
+    var dom = require("../lib/dom");
+    dom.importCssString(exports.cssText, exports.cssClass);
+});

--- a/script.js
+++ b/script.js
@@ -316,3 +316,51 @@ if (langSelector) {
         loadRules(e.target.value).then(updateView);
     });
 }
+
+// ====== Theme Handling ======
+function setTheme(theme) {
+    document.body.classList.toggle('dark-theme', theme === 'dark');
+    editor.setTheme(theme === 'dark' ? 'ace/theme/custom_dark' : 'ace/theme/chrome');
+    localStorage.setItem('verbalize-theme', theme);
+    updateView();
+}
+
+var themeSelector = document.getElementById('theme-selector');
+if (themeSelector) {
+    var saved = localStorage.getItem('verbalize-theme') || 'light';
+    themeSelector.value = saved;
+    setTheme(saved);
+    themeSelector.addEventListener('change', function (e) {
+        setTheme(e.target.value);
+    });
+}
+
+// ====== Keyboard Shortcuts ======
+function wrapSelection(wrapper) {
+    var range = editor.getSelectionRange();
+    var value = editor.session.getTextRange(range);
+    editor.session.replace(range, wrapper + value + wrapper);
+}
+
+editor.commands.addCommand({
+    name: 'bold',
+    bindKey: {win: 'Ctrl-B', mac: 'Command-B'},
+    exec: function(){ wrapSelection('**'); }
+});
+
+editor.commands.addCommand({
+    name: 'italic',
+    bindKey: {win: 'Ctrl-I', mac: 'Command-I'},
+    exec: function(){ wrapSelection('*'); }
+});
+
+editor.commands.addCommand({
+    name: 'toggleTheme',
+    bindKey: {win: 'Ctrl-D', mac: 'Command-D'},
+    exec: function(){
+        var current = document.body.classList.contains('dark-theme') ? 'dark' : 'light';
+        var next = current === 'dark' ? 'light' : 'dark';
+        if(themeSelector) themeSelector.value = next;
+        setTheme(next);
+    }
+});

--- a/style.css
+++ b/style.css
@@ -1,12 +1,36 @@
 /* Modernized General Styles */
+:root {
+    --bg-start: #f8fafc;
+    --bg-end: #e9ecef;
+    --text-color: #23272f;
+    --panel-bg: #fff;
+    --panel-muted: #f6f8fa;
+    --border-color: #e3e7ed;
+    --button-bg: #63666b;
+    --button-text: #fff;
+    --button-bg-hover: #1a325f;
+}
+
+body.dark-theme {
+    --bg-start: #1e1e1e;
+    --bg-end: #2b2b2b;
+    --text-color: #f1f1f1;
+    --panel-bg: #333;
+    --panel-muted: #383838;
+    --border-color: #555;
+    --button-bg: #555;
+    --button-text: #fff;
+    --button-bg-hover: #222;
+}
+
 body {
     font-family: 'Inter', 'Roboto', Arial, sans-serif;
     margin: 0;
     padding: 0;
     height: 100vh;
     overflow: hidden;
-    background: linear-gradient(120deg, #f8fafc 0%, #e9ecef 100%);
-    color: #23272f;
+    background: linear-gradient(120deg, var(--bg-start) 0%, var(--bg-end) 100%);
+    color: var(--text-color);
     letter-spacing: 0.01em;
 }
 
@@ -22,7 +46,7 @@ body {
 /* Editor Styles */
 #editor-container {
     width: 50%;
-    background: #fff;
+    background: var(--panel-bg);
     border-radius: 16px;
     box-shadow: 0 2px 16px 0 rgba(60,72,88,0.07);
     margin-right: 0;
@@ -40,7 +64,7 @@ body {
 #editor {
     flex: 1;
     width: 100%;
-    background: #f6f8fa;
+    background: var(--panel-muted);
     padding: 24px;
     border: none;
     outline: none;
@@ -56,7 +80,7 @@ body {
     width: 50%;
     display: flex;
     flex-direction: row;
-    background: #fff;
+    background: var(--panel-bg);
     border-radius: 16px;
     box-shadow: 0 2px 16px 0 rgba(60,72,88,0.07);
     overflow: hidden;
@@ -68,8 +92,8 @@ body {
     width: 70%;
     padding: 24px;
     overflow-y: auto;
-    background: #f8fafc;
-    border-right: 1px solid #e3e7ed;
+    background: var(--panel-muted);
+    border-right: 1px solid var(--border-color);
     box-sizing: border-box;
 }
 
@@ -77,14 +101,14 @@ body {
     width: 30%;
     padding: 24px;
     overflow-y: auto;
-    background: #fff;
+    background: var(--panel-bg);
     box-sizing: border-box;
 }
 
 #sidebar h3 {
     margin-top: 0;
     font-weight: 600;
-    color: #23272f;
+    color: var(--text-color);
     letter-spacing: 0.02em;
 }
 
@@ -93,7 +117,7 @@ body {
     margin-top: 1.2em;
     margin-bottom: 0.6em;
     font-weight: 600;
-    color: #23272f;
+    color: var(--text-color);
 }
 
 #mdview p {
@@ -112,7 +136,7 @@ body {
 }
 
 #mdview code {
-    background: #e3e7ed;
+    background: var(--border-color);
     padding: 3px 7px;
     border-radius: 6px;
     font-family: 'JetBrains Mono', 'Fira Mono', 'Courier New', monospace;
@@ -126,7 +150,7 @@ body {
     margin-bottom: 1.2em;
     border-collapse: separate;
     border-spacing: 0;
-    background: #fff;
+    background: var(--panel-bg);
     border-radius: 8px;
     overflow: hidden;
     box-shadow: 0 1px 4px 0 rgba(60,72,88,0.04);
@@ -135,14 +159,14 @@ body {
 #mdview th,
 #mdview td {
     padding: 14px 18px;
-    border-bottom: 1px solid #e3e7ed;
+    border-bottom: 1px solid var(--border-color);
     text-align: left;
 }
 
 #mdview th {
-    background: #f6f8fa;
+    background: var(--panel-muted);
     font-weight: 600;
-    color: #23272f;
+    color: var(--text-color);
 }
 
 #mdview tr:last-child td {
@@ -153,7 +177,7 @@ body {
 #warnings-panel, .warnings-panel {
     margin-bottom: 24px;
     padding: 16px 18px 12px 18px;
-    background: #f6f8fa;
+    background: var(--panel-muted);
     border-radius: 10px;
     box-shadow: 0 1px 4px 0 rgba(60,72,88,0.04);
 }
@@ -162,7 +186,7 @@ body {
     margin-top: 0;
     margin-bottom: 12px;
     font-size: 1.13em;
-    color: #23272f;
+    color: var(--text-color);
     font-weight: 700;
     letter-spacing: 0.01em;
 }
@@ -178,7 +202,7 @@ body {
     margin-bottom: 8px;
     padding: 7px 12px;
     border-radius: 7px;
-    background: #fff;
+    background: var(--panel-bg);
     font-size: 1em;
     color: #2d3a4a;
     box-shadow: 0 1px 2px 0 rgba(60,72,88,0.03);
@@ -210,8 +234,8 @@ body {
 /* Statistics Panel */
 #statistics {
     padding: 12px 28px;
-    background: #fff;
-    border-top: 1px solid #e3e7ed;
+    background: var(--panel-bg);
+    border-top: 1px solid var(--border-color);
     display: flex;
     justify-content: space-between;
     align-items: center;
@@ -245,8 +269,8 @@ body {
 }
 
 #file-actions button {
-    background: #63666b;
-    color: #fff;
+    background: var(--button-bg);
+    color: var(--button-text);
     border: none;
     border-radius: 8px;
     padding: 8px 18px;
@@ -258,8 +282,8 @@ body {
 }
 
 #file-actions button:hover, #file-actions button:focus {
-    background: #1a325f;
-    color: #fff;
+    background: var(--button-bg-hover);
+    color: var(--button-text);
     box-shadow: 0 2px 8px 0 rgba(60,72,88,0.13);
     outline: none;
 }
@@ -312,7 +336,7 @@ body {
     #mdview {
         width: 100%;
         border-right: none;
-        border-bottom: 1px solid #e3e7ed;
+        border-bottom: 1px solid var(--border-color);
     }
 
     #sidebar {
@@ -345,7 +369,7 @@ body {
 .metrics-panel {
     margin-bottom: 24px;
     padding: 16px 18px 12px 18px;
-    background: #f6f8fa;
+    background: var(--panel-muted);
     border-radius: 10px;
     box-shadow: 0 1px 4px 0 rgba(60,72,88,0.04);
 }
@@ -354,7 +378,7 @@ body {
     margin-top: 0;
     margin-bottom: 12px;
     font-size: 1.13em;
-    color: #23272f;
+    color: var(--text-color);
     font-weight: 700;
     letter-spacing: 0.01em;
 }


### PR DESCRIPTION
## Summary
- allow light/dark theme switcher and persist choice
- expose simple keyboard shortcuts (bold, italic and theme toggle)
- add minimal custom dark theme for Ace
- document new functionality

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840943149248333a20a9560034f51fe