### PR TITLE
Add report download feature

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,6 +62,7 @@
         <p>Avisos: <span id="warnings" class="text-success">0</span></p>
     </div>
     <div id="sugestao-texto-ia" class="mt-2"></div>
+    <button id="download-report" class="btn btn-secondary btn-sm">Baixar relatório</button>
 </div>
 
 <!-- Incluindo as bibliotecas JavaScript -->

--- a/style.css
+++ b/style.css
@@ -276,6 +276,29 @@ body {
     font-weight: 600;
 }
 
+/* Botão de download do relatório */
+#statistics button {
+    background: var(--button-bg);
+    color: var(--button-text);
+    border: none;
+    border-radius: 8px;
+    padding: 8px 18px;
+    font-size: 1em;
+    font-weight: 500;
+    cursor: pointer;
+    box-shadow: 0 1px 4px 0 rgba(60,72,88,0.07);
+    transition: background 0.2s, box-shadow 0.2s, color 0.2s;
+    margin-left: auto;
+}
+
+#statistics button:hover,
+#statistics button:focus {
+    background: var(--button-bg-hover);
+    color: var(--button-text);
+    box-shadow: 0 2px 8px 0 rgba(60,72,88,0.13);
+    outline: none;
+}
+
 /* File Actions & Buttons */
 #file-actions {
     display: flex;


### PR DESCRIPTION
## Summary
- add **Baixar relatório** button in the statistics bar
- style new bottom bar button
- expose last readability metrics and rule counts
- implement Markdown report generator and download handler

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68409f0bcb048333ab5acd3e21a60c2a