### PR TITLE
Enable Electron packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,7 @@ Verbalize is an advanced Markdown editor with grammatical and stylistic analysis
 3. Install Dependencies: `npm install`
 4. Start the Electron App: `npm start`
 5. Package the App (Optional): `npm run dist`
-
-> Packages will be generated in the `dist/` folder.
+   - Uses **electron-packager** to create binaries in the `dist/` folder.
 
 ## How to Use
 
@@ -165,8 +164,7 @@ Verbalize é um editor Markdown avançado com análise gramatical e estilística
 3. Instale as Dependências: `npm install`
 4. Inicie o Aplicativo Electron: `npm start`
 5. Empacotar o Aplicativo (Opcional): `npm run dist`
-
-> Os pacotes serão gerados na pasta `dist/`.
+   - Utiliza o **electron-packager** para gerar binários na pasta `dist/`.
 
 ## Como Usar
 

--- a/package.json
+++ b/package.json
@@ -4,10 +4,12 @@
   "description": "Verbalize - Editor Markdown com análise gramatical",
   "main": "main.js",
   "scripts": {
-    "start": "electron ."
+    "start": "electron .",
+    "dist": "electron-packager . verbalize --overwrite --out=dist"
   },
   "devDependencies": {
-    "electron": "^25.2.0"
+    "electron": "^25.2.0",
+    "electron-packager": "^17.1.1"
   },
   "author": "Paulo Duarte",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- add `dist` script and `electron-packager` dev dependency
- clarify packaging step in README for English and Portuguese documentation

## Testing
- `npm run dist` *(fails: electron-packager not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841a8dc53a08333889ebc2a3fdbc6e1