### PR TITLE
Enable Electron packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ Verbalize is an advanced Markdown editor with grammatical and stylistic analysis
 1. Clone the Repository: `git clone https://github.com/your-user/verbalize.git`
 2. Navigate to the Project Directory: `cd verbalize`
 3. Install Dependencies: `npm install`
-4. Start the Electron App: `npm start`
-5. Package the App (Optional): `npm run dist`
-
-> Packages will be generated in the `dist/` folder.
+4. Create a `.env` file with `MARITACA_API_KEY=<your_key>`
+5. Start the Electron App: `npm start`
+6. Package the App (Optional): `npm run dist`
+   - Uses **electron-packager** to create binaries in the `dist/` folder.
 
 ## How to Use
 
@@ -163,10 +163,10 @@ Verbalize é um editor Markdown avançado com análise gramatical e estilística
 1. Clone o Repositório: `git clone https://github.com/seu-usuario/verbalize.git`
 2. Navegue até o Diretório do Projeto: `cd verbalize`
 3. Instale as Dependências: `npm install`
-4. Inicie o Aplicativo Electron: `npm start`
-5. Empacotar o Aplicativo (Opcional): `npm run dist`
-
-> Os pacotes serão gerados na pasta `dist/`.
+4. Crie um arquivo `.env` com `MARITACA_API_KEY=<sua_chave>`
+5. Inicie o Aplicativo Electron: `npm start`
+6. Empacotar o Aplicativo (Opcional): `npm run dist`
+   - Utiliza o **electron-packager** para gerar binários na pasta `dist/`.
 
 ## Como Usar
 

--- a/package.json
+++ b/package.json
@@ -4,10 +4,12 @@
   "description": "Verbalize - Editor Markdown com análise gramatical",
   "main": "main.js",
   "scripts": {
-    "start": "electron ."
+    "start": "electron .",
+    "dist": "electron-packager . verbalize --overwrite --out=dist"
   },
   "devDependencies": {
-    "electron": "^25.2.0"
+    "electron": "^25.2.0",
+    "electron-packager": "^17.1.1"
   },
   "author": "Paulo Duarte",
   "license": "MIT",
@@ -21,6 +23,7 @@
     "jquery": "^3.7.1",
     "markdown-it": "^14.1.0",
     "markdown-it-footnote": "^4.0.0",
-    "popper.js": "^1.16.1"
+    "popper.js": "^1.16.1",
+    "dotenv": "^16.3.1"
   }
 }


### PR DESCRIPTION
## Summary
- add electron-packager `dist` script
- document packaging step in README
- add dotenv dependency for environment variables

## Testing
- `npm run dist` *(fails: electron-packager not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841a8dc53a08333889ebc2a3fdbc6e1