### PR TITLE
Fix Vale execution failure by automating binary installation

### DIFF
--- a/app/api/lint/route.ts
+++ b/app/api/lint/route.ts
@@ -39,7 +39,7 @@ BasedOnStyles = ${style}
     const iniFile = path.join(tmpDir, '.vale.ini');
     await fs.writeFile(iniFile, valeIni);
 
-    const valePath = path.join(process.cwd(), 'vale');
+    const valePath = path.join(process.cwd(), process.platform === 'win32' ? 'vale.exe' : 'vale');
 
     // Ensure the binary is executable. This is crucial for serverless environments
     // where file permissions might not be preserved during deployment.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "writer-app",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@tailwindcss/typography": "^0.5.19",
         "next": "16.1.6",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "postinstall": "node scripts/install-vale.js"
   },
   "dependencies": {
     "@tailwindcss/typography": "^0.5.19",

--- a/scripts/install-vale.js
+++ b/scripts/install-vale.js
@@ -1,0 +1,59 @@
+const os = require('os');
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const VERSION = '3.9.5';
+const platform = os.platform();
+const arch = os.arch();
+
+let url = '';
+let filename = '';
+let isZip = false;
+
+if (platform === 'linux' && arch === 'x64') {
+  filename = `vale_${VERSION}_Linux_64-bit.tar.gz`;
+} else if (platform === 'darwin') {
+  if (arch === 'arm64') {
+    filename = `vale_${VERSION}_macOS_arm64.tar.gz`;
+  } else {
+    filename = `vale_${VERSION}_macOS_64-bit.tar.gz`;
+  }
+} else if (platform === 'win32') {
+  filename = `vale_${VERSION}_Windows_64-bit.zip`;
+  isZip = true;
+}
+
+if (!filename) {
+  console.error(`Unsupported platform/architecture: ${platform}/${arch}`);
+  process.exit(0); // Exit gracefully to not block npm install
+}
+
+url = `https://github.com/errata-ai/vale/releases/download/v${VERSION}/${filename}`;
+
+const targetBinary = platform === 'win32' ? 'vale.exe' : 'vale';
+const tmpFile = path.join(os.tmpdir(), filename);
+
+try {
+  console.log(`Downloading Vale from ${url}...`);
+  execSync(`curl -L "${url}" -o "${tmpFile}"`);
+
+  if (isZip) {
+    console.log(`Extracting ${targetBinary} from zip...`);
+    // Using tar for zip extraction as it is more robust and available on modern Windows
+    execSync(`tar -xf "${tmpFile}" ${targetBinary}`);
+  } else {
+    console.log(`Extracting ${targetBinary} from tar.gz...`);
+    execSync(`tar -xzf "${tmpFile}" ${targetBinary}`);
+  }
+
+  if (platform !== 'win32') {
+    fs.chmodSync(path.join(process.cwd(), targetBinary), 0o755);
+  }
+
+  console.log(`Vale ${VERSION} installed successfully as ${targetBinary}`);
+  fs.unlinkSync(tmpFile);
+} catch (error) {
+  console.error('Failed to install Vale:', error.message);
+  process.exit(0); // Exit gracefully
+}


### PR DESCRIPTION
The "Linting failed: Vale execution failed" error was caused by the missing Vale binary in the project root. I resolved this by adding a `postinstall` script that automatically downloads and installs the correct Vale binary (v3.9.5) from GitHub releases based on the user's operating system and architecture. I also updated the backend API to handle platform-specific binary names (e.g., `vale.exe` on Windows).

---
*PR created automatically by Jules for task [1381885190195897681](https://jules.google.com/task/1381885190195897681) started by @mtgr18977*