### PR TITLE
Navigate to and highlight text when clicking sidebar alerts

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -130,6 +130,32 @@ export default function Home() {
     }
   };
 
+  const handleAlertClick = (alert: ValeAlert) => {
+    if (!editorRef.current) return;
+
+    const textarea = editorRef.current;
+    const lines = text.split('\n');
+    let offset = 0;
+
+    for (let i = 0; i < alert.Line - 1; i++) {
+      offset += lines[i].length + 1; // +1 for \n
+    }
+
+    const start = offset + alert.Span[0] - 1;
+    const end = offset + alert.Span[1];
+
+    textarea.focus();
+    textarea.setSelectionRange(start, end);
+
+    // Scroll selection into view centered
+    const lineHeight = 22.4; // Estimated line height for text-sm leading-relaxed
+    const scrollTo = (alert.Line - 1) * lineHeight - (textarea.clientHeight / 2);
+    textarea.scrollTo({
+      top: Math.max(0, scrollTo),
+      behavior: 'smooth'
+    });
+  };
+
   return (
     <div className="flex h-screen bg-gray-50 dark:bg-gray-950 text-gray-900 dark:text-gray-100 overflow-hidden font-sans">
       {/* Sidebar */}
@@ -347,10 +373,14 @@ export default function Home() {
               ) : (
                 <div className="space-y-3">
                   {results.map((alert, index) => (
-                    <div key={index} className={`p-4 rounded-xl border bg-white dark:bg-gray-800 shadow-sm transition-all hover:scale-[1.01] hover:shadow-md group ${
-                      alert.Severity === 'error' ? 'border-red-100 dark:border-red-900/30' :
-                      alert.Severity === 'warning' ? 'border-yellow-100 dark:border-yellow-900/30' : 'border-blue-100 dark:border-blue-900/30'
-                    }`}>
+                    <div
+                      key={index}
+                      onClick={() => handleAlertClick(alert)}
+                      className={`p-4 rounded-xl border bg-white dark:bg-gray-800 shadow-sm transition-all hover:scale-[1.01] hover:shadow-md hover:bg-gray-50 dark:hover:bg-gray-700/50 cursor-pointer group ${
+                        alert.Severity === 'error' ? 'border-red-100 dark:border-red-900/30' :
+                        alert.Severity === 'warning' ? 'border-yellow-100 dark:border-yellow-900/30' : 'border-blue-100 dark:border-blue-900/30'
+                      }`}
+                    >
                       <div className="flex items-start justify-between mb-2">
                         <span className={`text-[8px] font-black uppercase px-2 py-0.5 rounded shadow-sm ${
                           alert.Severity === 'error' ? 'bg-red-500 text-white' :

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next_server.log
+++ b/next_server.log
@@ -1,0 +1,42 @@
+
+> writer-app@0.1.0 dev
+> next dev
+
+▲ Next.js 16.1.6 (Turbopack)
+- Local:         http://localhost:3000
+- Network:       http://192.168.0.2:3000
+
+✓ Starting...
+✓ Ready in 3.5s
+ GET / 200 in 2.7s (compile: 2.3s, render: 371ms)
+ GET / 200 in 104ms (compile: 6ms, render: 98ms)
+ POST /api/lint 200 in 889ms (compile: 206ms, render: 684ms)
+ GET / 200 in 733ms (compile: 360ms, render: 373ms)
+ POST /api/lint 200 in 763ms (compile: 8ms, render: 755ms)
+ GET / 200 in 105ms (compile: 6ms, render: 99ms)
+ POST /api/lint 200 in 369ms (compile: 4ms, render: 366ms)
+ GET / 200 in 365ms (compile: 88ms, render: 277ms)
+ POST /api/lint 200 in 525ms (compile: 9ms, render: 516ms)
+ GET / 200 in 106ms (compile: 7ms, render: 100ms)
+ POST /api/lint 200 in 351ms (compile: 6ms, render: 345ms)
+ GET / 200 in 69ms (compile: 4ms, render: 66ms)
+ POST /api/lint 200 in 429ms (compile: 3ms, render: 426ms)
+ GET / 200 in 67ms (compile: 4ms, render: 63ms)
+ POST /api/lint 200 in 574ms (compile: 6ms, render: 568ms)
+ GET / 200 in 235ms (compile: 81ms, render: 154ms)
+ POST /api/lint 200 in 486ms (compile: 3ms, render: 483ms)
+ GET / 200 in 242ms (compile: 71ms, render: 171ms)
+ POST /api/lint 200 in 517ms (compile: 5ms, render: 513ms)
+ GET / 200 in 82ms (compile: 4ms, render: 78ms)
+ POST /api/lint 200 in 460ms (compile: 4ms, render: 456ms)
+ GET / 200 in 366ms (compile: 270ms, render: 97ms)
+ GET / 200 in 379ms (compile: 117ms, render: 262ms)
+ GET / 200 in 89ms (compile: 6ms, render: 83ms)
+ GET / 200 in 72ms (compile: 3ms, render: 69ms)
+ POST /api/lint 200 in 571ms (compile: 3ms, render: 568ms)
+ POST /api/lint 200 in 605ms (compile: 3ms, render: 602ms)
+ GET / 200 in 56ms (compile: 4ms, render: 52ms)
+ POST /api/lint 200 in 318ms (compile: 3ms, render: 315ms)
+ GET / 200 in 61ms (compile: 3ms, render: 58ms)
+ POST /api/lint 200 in 458ms (compile: 3ms, render: 456ms)
+[?25h


### PR DESCRIPTION
This change enables a core workflow for users: clicking a linting alert in the sidebar now automatically navigates the editor to the exact location of the issue and selects (highlights) the problematic text. 

Key changes:
- Logic to map Vale's 1-based `Line` and `Span` to a 0-based character offset for the `textarea`.
- Smooth scrolling integration to ensure the selected text is centered in the editor's viewport.
- UI enhancements for alert cards to indicate interactivity (pointer cursor and hover states).
- Robust verification using Playwright tests for single-line, multi-line, and scrolling scenarios.

---
*PR created automatically by Jules for task [8083227658139503043](https://jules.google.com/task/8083227658139503043) started by @mtgr18977*